### PR TITLE
Cardinal direction automation from dataframe

### DIFF
--- a/global.R
+++ b/global.R
@@ -1,3 +1,4 @@
+# Libraries
 library(shiny)
 library(leaflet)
 library(dplyr)
@@ -11,15 +12,40 @@ library(leaflet.extras)
 library(sp)
 library(rvest)
 
-# df <- read_csv("~/Google Drive/PhenoPostdoc/mapPortal/phenoSites.txt")
+# Variables
+table_url = 'https://phenocam.sr.unh.edu/webcam/network/siteinfo/?format=csv'
+df <- read.csv(url(table_url))
+colnames(df)
 
-# # variables
-url <- "https://phenocam.sr.unh.edu/webcam/network/table/"
-cams <- url %>%
-  read_html() %>%
-  html_nodes(xpath='//*[@id="main"]/table') %>%
-  html_table()
-
-cams_ = cams[[1]]
-site_names = cams_$Camera
 layers_ = providers[0:-1]
+# Data for all the sites
+cams_ = df
+# All site names from table
+site_names = df$site
+
+# Changing blank values in the camera orientation field to 'N' as a default
+cams_$camera_orientation[cams_$camera_orientation == ''] = 'N'
+
+orientation_key = list('N' = 0, 'NE' = 45, 'E' = 90, 'SE' = 135, 'S' = 180, 'SW' = 225, 'W' = 270, 'NW' = 315,
+                       'ENE' = 67, 'ESE' = 112, 'NNE' = 22, 'NNW' = 338, 'SSE' = 158, 'SSW' = 202, 'UP' = 0,
+                       'WNW' = 292, 'WSW' = 248)
+
+# orientation = as.character(cams_$camera_orientation[5])
+# orientation_key[orientation]
+  
+
+# Variables being used in code :
+#   site = Name of the phenocam site
+#   lat/lon = location of phenocam site
+#   elev = elevation of the site
+#   site_type = I, II, or III
+#   camera_orientation = direction the camera is pointing
+#   site_description = information about the phenocam site
+#   nimage = Number of images
+#   camera_description = Name of the camera / other
+#   active = bool (Active or Not)
+#   date_end = last date images collected on
+#   date_start = first date images collected on
+
+
+

--- a/global.R
+++ b/global.R
@@ -47,5 +47,7 @@ orientation_key = list('N' = 0, 'NE' = 45, 'E' = 90, 'SE' = 135, 'S' = 180, 'SW'
 #   date_end = last date images collected on
 #   date_start = first date images collected on
 
+# is not null function
+is.not.null <- function(x) ! is.null(x)
 
 

--- a/ui.R
+++ b/ui.R
@@ -26,7 +26,6 @@ ui = fluidPage(navbarPage("APIS Phenocam C.2", id="navbar",
                                       actionButton("usZoom", "Show Contiguous US"),
                                       actionButton('showSites', 'Show all Sites'),
                                       actionButton('testbutton', 'Test Button'),
-
                                       selectInput("site", "Phenocam Site Name", site_names, selected = NULL),
                                       # link to the phenocam site or you can use popup link
                                       a("Google", href='www.google.com', target="_blank"),
@@ -34,7 +33,7 @@ ui = fluidPage(navbarPage("APIS Phenocam C.2", id="navbar",
                                       
                                       selectInput("layer", "Layer", layers_, selected = 'Esri.WorldImagery' ),
                                       # checkboxInput("drawFOV", "DrawFOV", value = FALSE),
-                                      checkboxInput("drawROI", "DrawROI", value = FALSE),
+                                      checkboxInput("drawROI", "Draw ROI", value = FALSE),
                                       # sliderInput("opacity", "Opacity:", min = 0, max = 1, value = 0.0, step = 0.1),
                                       # selectInput("layer2", "Add Transparent Layer", layers_, 'Esri.NatGeoWorldMap')
                                       sliderInput("azm", "Azm:", min = 0, max = 360, value = 0.0, step = 5)

--- a/ui.R
+++ b/ui.R
@@ -25,8 +25,9 @@ ui = fluidPage(navbarPage("APIS Phenocam C.2", id="navbar",
                                       h2("Site explorer"),
                                       actionButton("usZoom", "Show Contiguous US"),
                                       actionButton('showSites', 'Show all Sites'),
+                                      actionButton('testbutton', 'Test Button'),
 
-                                      selectInput("site", "Phenocam Site Name", site_names, selected = 'unca' ),
+                                      selectInput("site", "Phenocam Site Name", site_names, selected = NULL),
                                       # link to the phenocam site or you can use popup link
                                       a("Google", href='www.google.com', target="_blank"),
                                       

--- a/ui.R
+++ b/ui.R
@@ -26,7 +26,11 @@ ui = fluidPage(navbarPage("APIS Phenocam C.2", id="navbar",
                                       actionButton("usZoom", "Show Contiguous US"),
                                       actionButton('showSites', 'Show all Sites'),
 
-                                      selectInput("site", "Phenocam Site Name", site_names, selected = 'poudreriver' ),
+                                      selectInput("site", "Phenocam Site Name", site_names, selected = 'unca' ),
+                                      # link to the phenocam site or you can use popup link
+                                      a("Google", href='www.google.com', target="_blank"),
+                                      
+                                      
                                       selectInput("layer", "Layer", layers_, selected = 'Esri.WorldImagery' ),
                                       # checkboxInput("drawFOV", "DrawFOV", value = FALSE),
                                       checkboxInput("drawROI", "DrawROI", value = FALSE),


### PR DESCRIPTION
based on 'N', 'NW', etc.. calculate the azm direction and then automate the display when drawFOV is clicked. 
- Also added functionality in clicking any site marker when all are displayed so that it zooms to clicked site marker.  
- fixed some zoom bugs and switched the start view to the contiguous United States using a counter work-around fix within shiny.